### PR TITLE
Pin reframework version

### DIFF
--- a/REFix.vcxproj
+++ b/REFix.vcxproj
@@ -159,6 +159,7 @@
     <ClInclude Include="init.h" />
     <ClInclude Include="REFix.h" />
     <ClInclude Include="Undamper.h" />
+    <ClInclude Include="Version.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AnimationCurveMutator.cpp" />
@@ -167,6 +168,7 @@
     <ClCompile Include="Hooks.cpp" />
     <ClCompile Include="init.cpp" />
     <ClCompile Include="Undamper.cpp" />
+    <ClCompile Include="Version.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Version.cpp
+++ b/Version.cpp
@@ -1,0 +1,8 @@
+#include "Version.h"
+
+void reframework_plugin_required_version(REFrameworkPluginVersion* version) {
+    version->major = REFRAMEWORK_PLUGIN_VERSION_MAJOR;
+    version->minor = REFRAMEWORK_PLUGIN_VERSION_MINOR;
+    version->patch = REFRAMEWORK_PLUGIN_VERSION_PATCH;
+    version->game_name = "RE2";
+}

--- a/Version.cpp
+++ b/Version.cpp
@@ -4,5 +4,5 @@ void reframework_plugin_required_version(REFrameworkPluginVersion* version) {
     version->major = REFRAMEWORK_PLUGIN_VERSION_MAJOR;
     version->minor = REFRAMEWORK_PLUGIN_VERSION_MINOR;
     version->patch = REFRAMEWORK_PLUGIN_VERSION_PATCH;
-    version->game_name = "RE2";
+    version->game_name = "RE2_TDB66";
 }

--- a/Version.h
+++ b/Version.h
@@ -1,0 +1,4 @@
+#pragma once
+#include "REFix.h"
+
+extern "C" __declspec(dllexport) void reframework_plugin_required_version(REFrameworkPluginVersion * version);


### PR DESCRIPTION
This PR makes the plugin only work with the version of REFramework it was compiled against to prevent issues. It also prevents the user from loading the plugin on any game+version combo other than RE2 DX11 (non-RT).