### PR TITLE
Fix Init Failure

### DIFF
--- a/AnimCurveFlattener.cpp
+++ b/AnimCurveFlattener.cpp
@@ -5,7 +5,8 @@ namespace REFix {
 
     AnimationCurveFlattener::AnimationCurveFlattener(float v) : value(v) {}
 
-        *(float*)value_field->get_data_raw(key_frame, true) = value;
     void AnimationCurveFlattener::operate(void* key_frame) const {
+        float& data = value_field->get_data<float>(key_frame, true);
+        data = value;
     }
 }

--- a/AnimCurveFlattener.cpp
+++ b/AnimCurveFlattener.cpp
@@ -5,7 +5,7 @@ namespace REFix {
 
     AnimationCurveFlattener::AnimationCurveFlattener(float v) : value(v) {}
 
-    void AnimationCurveFlattener::operate(REF::API::ManagedObject* key_frame) const {
         *(float*)value_field->get_data_raw(key_frame, true) = value;
+    void AnimationCurveFlattener::operate(void* key_frame) const {
     }
 }

--- a/AnimCurveFlattener.cpp
+++ b/AnimCurveFlattener.cpp
@@ -7,6 +7,7 @@ namespace REFix {
 
     void AnimationCurveFlattener::operate(void* key_frame) const {
         float& data = value_field->get_data<float>(key_frame, true);
+        LOG_INFO("Anim key original value: %f", data);
         data = value;
     }
 }

--- a/AnimCurveFlattener.h
+++ b/AnimCurveFlattener.h
@@ -17,6 +17,6 @@ namespace REFix {
         AnimationCurveFlattener(float v);
 
     protected:
-        void operate(REF::API::ManagedObject* key_frame) const;
+        void operate(void* key_frame) const;
     };
 }

--- a/AnimCurveStraightener.cpp
+++ b/AnimCurveStraightener.cpp
@@ -8,6 +8,7 @@ namespace REFix {
     void AnimationCurveStraightener::operate(void* key_frame) const {
         uint32_t& in_normal = in_normal_field->get_data<uint32_t>(key_frame, true);
         uint32_t& out_normal = out_normal_field->get_data<uint32_t>(key_frame, true);
+        LOG_INFO("Anim key original normal: (%u, %u)", in_normal, out_normal);
         in_normal = 0U;
         out_normal = 0U;
     }

--- a/AnimCurveStraightener.cpp
+++ b/AnimCurveStraightener.cpp
@@ -5,8 +5,10 @@ namespace REFix {
     extern const REF::API::Field* in_normal_field;
     extern const REF::API::Field* out_normal_field;
 
-        *(uint32_t*)in_normal_field->get_data_raw(key_frame, true) = 0U;
-        *(uint32_t*)out_normal_field->get_data_raw(key_frame, true) = 0U;
     void AnimationCurveStraightener::operate(void* key_frame) const {
+        uint32_t& in_normal = in_normal_field->get_data<uint32_t>(key_frame, true);
+        uint32_t& out_normal = out_normal_field->get_data<uint32_t>(key_frame, true);
+        in_normal = 0U;
+        out_normal = 0U;
     }
 }

--- a/AnimCurveStraightener.cpp
+++ b/AnimCurveStraightener.cpp
@@ -5,8 +5,8 @@ namespace REFix {
     extern const REF::API::Field* in_normal_field;
     extern const REF::API::Field* out_normal_field;
 
-    void AnimationCurveStraightener::operate(REF::API::ManagedObject* key_frame) const {
         *(uint32_t*)in_normal_field->get_data_raw(key_frame, true) = 0U;
         *(uint32_t*)out_normal_field->get_data_raw(key_frame, true) = 0U;
+    void AnimationCurveStraightener::operate(void* key_frame) const {
     }
 }

--- a/AnimCurveStraightener.h
+++ b/AnimCurveStraightener.h
@@ -8,6 +8,6 @@ namespace REFix {
     /// </summary>
     class AnimationCurveStraightener : public AnimationCurveMutator {
     protected:
-        void operate(REF::API::ManagedObject* key_frame) const;
+        void operate(void* key_frame) const;
     };
 }

--- a/AnimationCurveMutator.cpp
+++ b/AnimationCurveMutator.cpp
@@ -14,15 +14,15 @@ namespace REFix {
         const uint32_t key_count = get_keys_count->call<uint32_t>(context, animation_curve);
 
         for (uint32_t i = 0U; i < key_count; i++) {
-            const REF::API::ManagedObject* const keys_result = get_keys->call<REF::API::ManagedObject*>(key_frame, context, animation_curve, i);
+            const REF::API::ManagedObject* const keys_result = get_keys->call<REF::API::ManagedObject*>(key_frame, VMC(), animation_curve, i);
 
-            if (keys_result == 0) {
-                REF::API::get()->log_warn("[REFix] Failed to retrieve KeyFrame %u for animation curve %p", i, animation_curve);
+            if (keys_result == nullptr) {
+               LOG_WARN("Failed to retrieve KeyFrame %u for animation curve %p", i, animation_curve);
                 continue;
             }
 
             operate(key_frame);
-            set_keys->call(context, animation_curve, i, key_frame);
+            set_keys->call(VMC(), animation_curve, i, key_frame);
         }
     }
 }

--- a/AnimationCurveMutator.cpp
+++ b/AnimationCurveMutator.cpp
@@ -1,5 +1,6 @@
 #include "AnimationCurveMutator.h"
 #include <cstdint>
+#include <cstdlib>
 
 namespace REFix {
     extern const REF::API::TypeDefinition* key_frame_type;
@@ -8,10 +9,8 @@ namespace REFix {
     extern const REF::API::Method* set_keys;
 
     void AnimationCurveMutator::mutate(const REF::API::ManagedObject* animation_curve) const {
-        const REF::API::VMContext* const context = REF::API::get()->get_vm_context();
-
-        REF::API::ManagedObject* const key_frame = key_frame_type->create_instance();
-        const uint32_t key_count = get_keys_count->call<uint32_t>(context, animation_curve);
+        void* const key_frame = std::malloc(key_frame_type->get_valuetype_size());
+        const uint32_t key_count = get_keys_count->call<uint32_t>(VMC(), animation_curve);
 
         for (uint32_t i = 0U; i < key_count; i++) {
             const REF::API::ManagedObject* const keys_result = get_keys->call<REF::API::ManagedObject*>(key_frame, VMC(), animation_curve, i);
@@ -24,5 +23,7 @@ namespace REFix {
             operate(key_frame);
             set_keys->call(VMC(), animation_curve, i, key_frame);
         }
+
+        std::free(key_frame);
     }
 }

--- a/AnimationCurveMutator.h
+++ b/AnimationCurveMutator.h
@@ -11,6 +11,6 @@ namespace REFix {
         void mutate(const REF::API::ManagedObject* animation_curve) const;
 
     protected:
-        virtual void operate(REF::API::ManagedObject* key_frame) const = 0;
+        virtual void operate(void* key_frame) const = 0;
     };
 }

--- a/Hooks.cpp
+++ b/Hooks.cpp
@@ -2,7 +2,7 @@
 #include "Enums.h"
 
 namespace REFix {
-    const float DEFAULT_FOV = 90.0f;
+    static const float DEFAULT_FOV = 90.0f;
     extern const REF::API::Field* camera_param_field;
     extern const REF::API::Field* field_of_view_field;
 

--- a/Hooks.cpp
+++ b/Hooks.cpp
@@ -8,7 +8,7 @@ namespace REFix {
 
     int pre_update_pitch_yaw(int argc, void** argv, REFrameworkTypeDefinitionHandle* arg_tys, unsigned long long ret_addr) {
         REF::API::ManagedObject* const camera_param = camera_param_field->get_data<REF::API::ManagedObject*>(argv[1]);
-        const float fov = *(float*)field_of_view_field->get_data_raw(camera_param);
+        const float fov = field_of_view_field->get_data<float>(camera_param);
         float* input = (float*)&argv[2];
         *input *= fov;
         *input /= DEFAULT_FOV;

--- a/REFix.h
+++ b/REFix.h
@@ -27,9 +27,9 @@ namespace REF = reframework;
 
 #define VMC() REF::API::get()->get_vm_context()
 
-#define LOG_INFO(s, ...) REF::API::get()->log_info(s __VA_OPT__(,) __VA_ARGS__)
-#define LOG_WARN(s, ...) REF::API::get()->log_warn(s __VA_OPT__(,) __VA_ARGS__)
-#define LOG_ERROR(s, ...) REF::API::get()->log_error(s __VA_OPT__(,) __VA_ARGS__)
+#define LOG_INFO(s, ...) REF::API::get()->log_info("[REFix] " s __VA_OPT__(,) __VA_ARGS__)
+#define LOG_WARN(s, ...) REF::API::get()->log_warn("[REFix] " s __VA_OPT__(,) __VA_ARGS__)
+#define LOG_ERROR(s, ...) REF::API::get()->log_error("[REFix] " s __VA_OPT__(,) __VA_ARGS__)
 
 // Print a pointer location to the log.
 #define PRINT_PTR(ptr) LOG_INFO(#ptr " found at %p", (ptr))

--- a/REFix.h
+++ b/REFix.h
@@ -23,6 +23,17 @@
 
 namespace REF = reframework;
 
+#define TDB() REF::API::get()->tdb()
+
+#define VMC() REF::API::get()->get_vm_context()
+
+#define LOG_INFO(s, ...) REF::API::get()->log_info(s __VA_OPT__(,) __VA_ARGS__)
+#define LOG_WARN(s, ...) REF::API::get()->log_warn(s __VA_OPT__(,) __VA_ARGS__)
+#define LOG_ERROR(s, ...) REF::API::get()->log_error(s __VA_OPT__(,) __VA_ARGS__)
+
+// Print a pointer location to the log.
+#define PRINT_PTR(ptr) LOG_INFO(#ptr " found at %p", (ptr))
+
 namespace REFix {
     static void post_hook_null(void** ret_val, REFrameworkTypeDefinitionHandle ret_ty, unsigned long long ret_addr) {}
 }

--- a/REFix.vcxproj
+++ b/REFix.vcxproj
@@ -158,6 +158,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalIncludeDirectories>REFramework\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -174,6 +175,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalIncludeDirectories>REFramework\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -190,6 +192,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalIncludeDirectories>REFramework\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -206,6 +209,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalIncludeDirectories>REFramework\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -224,6 +228,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalIncludeDirectories>REFramework\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -244,6 +249,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalIncludeDirectories>REFramework\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -264,6 +270,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalIncludeDirectories>REFramework\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -284,6 +291,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalIncludeDirectories>REFramework\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Undamper.cpp
+++ b/Undamper.cpp
@@ -4,6 +4,7 @@ namespace REFix {
     Undamper::Undamper(const REF::API::TypeDefinition* damping_struct_type) : damping_time(damping_struct_type->find_field("DampingTime")) {}
 
     void Undamper::undamp(REF::API::ManagedObject* damping_struct) const {
-        *(float*)this->damping_time->get_data_raw(damping_struct) = 0.0f;
+        float& damptime = this->damping_time->get_data<float>(damping_struct);
+        damptime = 0.0f;
     }
 }

--- a/Undamper.cpp
+++ b/Undamper.cpp
@@ -5,6 +5,7 @@ namespace REFix {
 
     void Undamper::undamp(REF::API::ManagedObject* damping_struct) const {
         float& damptime = this->damping_time->get_data<float>(damping_struct);
+        LOG_INFO("Damping time: %f", damptime);
         damptime = 0.0f;
     }
 }

--- a/init.cpp
+++ b/init.cpp
@@ -106,9 +106,13 @@ namespace REFix {
 
         const REF::API::TypeDefinition* const animation_curve_type = TDB()->find_type("via.AnimationCurve");
         get_keys_count = animation_curve_type->find_method("getKeysCount");
+        PRINT_PTR(get_keys_count);
         get_keys = animation_curve_type->find_method("getKeys");
+        PRINT_PTR(get_keys);
         set_keys = animation_curve_type->find_method("setKeys");
+        PRINT_PTR(set_keys);
         key_frame_type = TDB()->find_type("via.KeyFrame");
+        PRINT_PTR(key_frame_type);
         const REF::API::Method* const get_camera_controller = TDB()->find_method(PREFIX ".camera.CameraSystem", "getCameraController");
 
         // Get the player camera controller.
@@ -121,6 +125,7 @@ namespace REFix {
             return false;
         }
 
+        PRINT_PTR(camera_system);
         const REF::API::ManagedObject* const player_camera_controller = get_camera_controller->call<REF::API::ManagedObject*>(VMC(), camera_system, 0);
 
         if (player_camera_controller == nullptr) {
@@ -153,6 +158,7 @@ namespace REFix {
 
         if (check_or_set("disable-input-pitch-scaling")) {
             value_field = key_frame_type->find_field("value");
+            PRINT_PTR(value_field);
             disable_input_pitch_scaling(twirler_camera_settings);
 
 #ifdef RE3
@@ -162,8 +168,11 @@ namespace REFix {
 
         if (check_or_set("remove-input-damping")) {
             in_normal_field = key_frame_type->find_field("inNormal");
+            PRINT_PTR(in_normal_field);
             out_normal_field = key_frame_type->find_field("outNormal");
+            PRINT_PTR(out_normal_field);
             damping_struct_single = TDB()->find_type(PREFIX ".DampingStruct`1<System.Single>");
+            PRINT_PTR(damping_struct_single);
             remove_input_damping(twirler_camera_settings, player_camera_controller);
 
 #ifdef RE3
@@ -175,7 +184,9 @@ namespace REFix {
             // Scale the input by the current FOV.
 
             camera_param_field = TDB()->find_field(PREFIX ".camera.CameraControllerRoot", "<CameraParam>k__BackingField");
+            PRINT_PTR(camera_param_field);
             field_of_view_field = TDB()->find_field(PREFIX ".CameraParam", "FieldOfView");
+            PRINT_PTR(field_of_view_field);
             const REF::API::TypeDefinition* const twirler_camera_controller_root_type = TDB()->find_type(PREFIX ".camera.TwirlerCameraControllerRoot");
             twirler_camera_controller_root_type->find_method("updatePitch")->add_hook(pre_update_pitch_yaw, post_hook_null, false);
             twirler_camera_controller_root_type->find_method("updateYaw")->add_hook(pre_update_pitch_yaw, post_hook_null, false);

--- a/init.cpp
+++ b/init.cpp
@@ -140,7 +140,7 @@ namespace REFix {
         PRINT_PTR(twirler_camera_settings);
 
 #ifdef RE3
-        const REF::API::ManagedObject* const sight_twirler_camera_settings = *player_camera_controller->get_field<REF::API::ManagedObject*>("TwirlerCameraSettings");
+        const REF::API::ManagedObject* const sight_twirler_camera_settings = *player_sight_camera_controller->get_field<REF::API::ManagedObject*>("TwirlerCameraSettings");
         PRINT_PTR(sight_twirler_camera_settings);
 #endif
 

--- a/init.cpp
+++ b/init.cpp
@@ -22,7 +22,7 @@ namespace REFix {
     const REF::API::TypeDefinition* damping_struct_single;
     libconfig::Config config;
 
-    bool check_or_set(const char* name) {
+    static bool check_or_set(const char* name) {
         bool value = true;
 
         if (!config.lookupValue(name, value)) {
@@ -32,7 +32,7 @@ namespace REFix {
         return value;
     }
 
-    void disable_input_pitch_scaling(const reframework::API::ManagedObject* twirler_camera_settings)
+    static void disable_input_pitch_scaling(const reframework::API::ManagedObject* twirler_camera_settings)
     {
         // Get the speed curves.
 
@@ -50,7 +50,7 @@ namespace REFix {
         REF::API::get()->log_info("[REFix] Hold speed curve flattened.");
     }
 
-    void remove_input_damping(
+    static void remove_input_damping(
         const reframework::API::ManagedObject* twirler_camera_settings,
         const reframework::API::ManagedObject* camera_controller
     )
@@ -83,7 +83,7 @@ namespace REFix {
         REF::API::get()->log_info("[REFix] Twirl speed pitch undamped.");
     }
 
-    bool init() {
+    static bool init() {
         if (!fs::create_directory(
             fs::path(".\\reframework\\data", fs::path::native_format)
         )) {

--- a/init.cpp
+++ b/init.cpp
@@ -136,6 +136,8 @@ namespace REFix {
         PRINT_PTR(player_camera_controller);
 
 #ifdef RE3
+        // Get the player sight camera controller.
+
         const REF::API::ManagedObject* const player_sight_camera_controller = get_camera_controller->call<REF::API::ManagedObject*>(VMC(), camera_system, 1);
 
         if (player_sight_camera_controller == nullptr) {
@@ -214,7 +216,7 @@ namespace REFix {
         catch (const libconfig::FileIOException&) {
             LOG_WARN("Could not write to the config.");
         }
-
+        
         return true;
     }
 }

--- a/init.cpp
+++ b/init.cpp
@@ -1,4 +1,6 @@
 #include <filesystem>
+#include <thread>
+#include <chrono>
 #include <libconfig.h++>
 
 #include "REFix.h"
@@ -204,5 +206,14 @@ namespace REFix {
 
 bool reframework_plugin_initialize(const REFrameworkPluginInitializeParam* param) {
     REF::API::initialize(param);
-    return REFix::init();
+    LOG_INFO("Running setup...");
+
+    while (!REFix::init())
+    {
+        LOG_INFO("Setup failed. Retrying...");
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+    LOG_INFO("Setup completed.");
+    return true;
 }

--- a/init.cpp
+++ b/init.cpp
@@ -114,6 +114,13 @@ namespace REFix {
         // Get the player camera controller.
 
         const REF::API::ManagedObject* const camera_system = REF::API::get()->get_managed_singleton(PREFIX ".camera.CameraSystem");
+
+        if (camera_system == nullptr)
+        {
+            LOG_ERROR("Could not get Camera System singleton.");
+            return false;
+        }
+
         const REF::API::ManagedObject* const player_camera_controller = get_camera_controller->call<REF::API::ManagedObject*>(VMC(), camera_system, 0);
 
         if (player_camera_controller == nullptr) {


### PR DESCRIPTION
- Fixes intialization failing because the plugin loads too quickly (introduced with RE Framework 1.5.7).
- Adds macros for various common functions, making the code cleaner.
- Makes some functions and variables static.
- Fixes a bug with RE3 where the first person controls weren't being made 1:1.
- Adds more logging statements.
- Actually constructs and uses `KeyFrame`s properly.
- Updates the RE Framework submodule to 1.5.7 (does nothing as the API hasn't changed).