### PR TITLE
Remove Input Scaling

### DIFF
--- a/Enums.h
+++ b/Enums.h
@@ -14,4 +14,10 @@ namespace REFix {
         PlUseDefenceItem = 8,
         FromDebug = 9
     };
+
+    enum class InputMode : int32_t
+    {
+        Pad = 0,
+        MouseKeyboard = 1
+    };
 }

--- a/Hooks.cpp
+++ b/Hooks.cpp
@@ -35,4 +35,14 @@ namespace REFix {
         *level = 0;
         return REFRAMEWORK_HOOK_CALL_ORIGINAL;
     }
+
+    void post_get_control_magnitude(void** ret_val, REFrameworkTypeDefinitionHandle ret_ty, unsigned long long ret_addr)
+    {
+        float* magnitude = (float*)ret_val;
+
+        if (*magnitude > 0.0f)
+        {
+            *magnitude = 1.0f;
+        }
+    }
 }

--- a/Hooks.cpp
+++ b/Hooks.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include "Hooks.h"
 #include "Enums.h"
 
@@ -5,6 +6,8 @@ namespace REFix {
     static const float DEFAULT_FOV = 90.0f;
     extern const REF::API::Field* camera_param_field;
     extern const REF::API::Field* field_of_view_field;
+    extern REF::API::ManagedObject* input_system;
+    extern const REF::API::Field* input_system_input_mode;
 
     int pre_update_pitch_yaw(int argc, void** argv, REFrameworkTypeDefinitionHandle* arg_tys, unsigned long long ret_addr) {
         REF::API::ManagedObject* const camera_param = camera_param_field->get_data<REF::API::ManagedObject*>(argv[1]);
@@ -38,9 +41,10 @@ namespace REFix {
 
     void post_get_control_magnitude(void** ret_val, REFrameworkTypeDefinitionHandle ret_ty, unsigned long long ret_addr)
     {
+        const InputMode mode = input_system_input_mode->get_data<InputMode>(input_system);
         float* magnitude = (float*)ret_val;
 
-        if (*magnitude > 0.0f)
+        if (mode == InputMode::MouseKeyboard && *magnitude > 0.0f)
         {
             *magnitude = 1.0f;
         }

--- a/Hooks.h
+++ b/Hooks.h
@@ -5,4 +5,5 @@ namespace REFix {
     int pre_update_pitch_yaw(int argc, void** argv, REFrameworkTypeDefinitionHandle* arg_tys, unsigned long long ret_addr);
     int pre_add_rank_point_direct(int argc, void** argv, REFrameworkTypeDefinitionHandle* arg_tys, unsigned long long ret_addr);
     int pre_set_interval_level(int argc, void** argv, REFrameworkTypeDefinitionHandle* arg_tys, unsigned long long ret_addr);
+    void post_get_control_magnitude(void** ret_val, REFrameworkTypeDefinitionHandle ret_ty, unsigned long long ret_addr);
 }

--- a/README.md
+++ b/README.md
@@ -21,8 +21,12 @@ The mouse sensitivity decreases when the FOV is lower and vice versa. This is mo
 Normally, certain actions in the game suck as firing a weapon, damaging an enemy, or taking damage yourself will cause the difficulty scale of the game to be adjusted slightly. This adds up over the course of a playthrough, resulting in unfairly tanky enemies if you play too well; therefore, the best strategy is to periodically take intentional damage to keep the game's difficulty low. This is undesireable because it actually rewards the player for playing worse, and lowers the skill ceiling by not allowing the player to get a feel for how many hits it takes to defeat each enemy. This mod removes this feature, although scripted difficulty changes are still present. For example, the difficult setting starts out low during the intro sequence at the gas station and then increases upon entering RPD.
 
 ### Improves zombie animation framerate
-
 At low LODs, the framerate of the zombie animations is reduced in order to save some processing power. This looks really bad though, and it barely saves any CPU time, so this mod forces all zombies to animate at full speed. This functionality is reverse-engineered from TheEggPie's mod that does the same exact thing. See https://www.nexusmods.com/residentevil22019/mods/728.
+
+### Removes Input Scaling
+Normally, the user's input is scaled by the magnitude of the right control stick. This works fine when playing with a controller but it's not implemented correctly
+for mouse input. The game incorrectly reports the "control stick" as being held at half strength sometimes, causing the player's mouse movements to be half as strong
+as they're supposed to be. This plugin corrects this behavior by forcing the game to report either 0 or 1 for the control stick magnitude at all times when playing with a mouse.
 
 ## Installation
 ### Prerequisites

--- a/REFix.h
+++ b/REFix.h
@@ -35,6 +35,11 @@ namespace REF = reframework;
 #define PRINT_PTR(ptr) LOG_INFO(#ptr " found at %p", (ptr))
 
 namespace REFix {
+    static int pre_hook_null(int argc, void** argv, REFrameworkTypeDefinitionHandle* arg_tys, unsigned long long ret_addr)
+    {
+        return REFRAMEWORK_HOOK_CALL_ORIGINAL;
+    }
+
     static void post_hook_null(void** ret_val, REFrameworkTypeDefinitionHandle ret_ty, unsigned long long ret_addr) {}
 }
 

--- a/init.cpp
+++ b/init.cpp
@@ -193,7 +193,6 @@ namespace REFix {
             PRINT_PTR(camera_param_field);
             field_of_view_field = TDB()->find_field(PREFIX ".CameraParam", "FieldOfView");
             PRINT_PTR(field_of_view_field);
-            
             twirler_camera_controller_root_type->find_method("updatePitch")->add_hook(pre_update_pitch_yaw, post_hook_null, false);
             twirler_camera_controller_root_type->find_method("updateYaw")->add_hook(pre_update_pitch_yaw, post_hook_null, false);
         }

--- a/init.cpp
+++ b/init.cpp
@@ -22,6 +22,8 @@ namespace REFix {
     const REF::API::Field* camera_param_field;
     const REF::API::Field* field_of_view_field;
     const REF::API::TypeDefinition* damping_struct_single;
+    REF::API::ManagedObject* input_system;
+    const REF::API::Field* input_system_input_mode;
     libconfig::Config config;
 
     static bool check_or_set(const char* name) {
@@ -198,8 +200,19 @@ namespace REFix {
 
         if (check_or_set("remove-input-scaling"))
         {
-            // Don't scale input by control magnitude.
+            // Don't scale input by control magnitude on mouse and keyboard.
 
+            input_system = REF::API::get()->get_managed_singleton(PREFIX ".InputSystem");
+            
+            if (input_system == nullptr)
+            {
+                LOG_ERROR("Could not get input system singleton.");
+                return false;
+            }
+
+            PRINT_PTR(input_system);
+            input_system_input_mode = TDB()->find_field(PREFIX ".InputSystem", "<InputMode>k__BackingField");
+            PRINT_PTR(input_system_input_mode);
             twirler_camera_controller_root_type->find_method("getControlMagnitude")->add_hook(pre_hook_null, post_get_control_magnitude, false);
         }
 

--- a/init.cpp
+++ b/init.cpp
@@ -182,6 +182,8 @@ namespace REFix {
 #endif
         }
 
+        const REF::API::TypeDefinition* const twirler_camera_controller_root_type = TDB()->find_type(PREFIX ".camera.TwirlerCameraControllerRoot");
+
         if (check_or_set("scale-input-with-fov")) {
             // Scale the input by the current FOV.
 
@@ -189,9 +191,16 @@ namespace REFix {
             PRINT_PTR(camera_param_field);
             field_of_view_field = TDB()->find_field(PREFIX ".CameraParam", "FieldOfView");
             PRINT_PTR(field_of_view_field);
-            const REF::API::TypeDefinition* const twirler_camera_controller_root_type = TDB()->find_type(PREFIX ".camera.TwirlerCameraControllerRoot");
+            
             twirler_camera_controller_root_type->find_method("updatePitch")->add_hook(pre_update_pitch_yaw, post_hook_null, false);
             twirler_camera_controller_root_type->find_method("updateYaw")->add_hook(pre_update_pitch_yaw, post_hook_null, false);
+        }
+
+        if (check_or_set("remove-input-scaling"))
+        {
+            // Don't scale input by control magnitude.
+
+            twirler_camera_controller_root_type->find_method("getControlMagnitude")->add_hook(pre_hook_null, post_get_control_magnitude, false);
         }
 
         if (check_or_set("remove-dynamic-difficulty"))


### PR DESCRIPTION
This PR fixes an issue where mouse input is sometimes scaled by half, especially when the player moves their mouse at a low speed. Build for testing: [REFix.zip](https://github.com/user-attachments/files/20234907/REFix.zip).